### PR TITLE
extract places from article titles

### DIFF
--- a/golden-standard-places.json
+++ b/golden-standard-places.json
@@ -1,0 +1,135 @@
+[
+    {
+        "title": "Voormalig burgemeester van Staden Francesco Vanderjeugd veroordeeld tot 1 jaar cel met uitstel voor verduistering en belangenvermenging  ",
+        "places": [
+            {
+                "name": "Staden",
+                "type": "municipality"
+            }
+        ],
+        "difficulty": "Long title."
+    },
+    {
+        "title": "Chipszakken moeten kraken, anders zouden we chips niet lekker meer vinden ",
+        "places": [],
+        "difficulty": "No places mentioned in title."
+    },
+    {
+        "title": "Congolese M23-rebellen nemen dan toch niet deel aan vredesgesprekken in Angola",
+        "places": [
+            {
+                "name": "Congo",
+                "type": "country"
+            },
+            {
+                "name": "Angola",
+                "type": "country"
+            }
+        ],
+        "difficulty": "Congolese is adjective form of place name Congo."
+    },
+    {
+        "title": "Van reusachtig groot tot onooglijk klein: maak kennis met de hoofdrolspelers uit 'De wilde Noordzee'",
+        "places": [
+            {
+                "name": "Noordzee",
+                "type": "other"
+            }
+        ],
+        "difficulty": "Noordzee is a place mentioned as part of film title 'De wilde Noordzee' and is of type other."
+    },
+    {
+        "title": "Europese Commissie komt met actieplan om kreunende staalsector te helpen",
+        "places": [],
+        "difficulty": "Europese Commissie is fixed phrase, no specific focus on place Europe."
+    },
+    {
+        "title": "Donald Trump en Vladimir Poetin bellen elkaar, hoe verloopt een gesprek tussen zulke wereldleiders?",
+        "places": [],
+        "difficulty": "Although they both represent countries, the countries aren't mentioned explicitly in the title."
+    },
+    {
+        "title": "Pommelien Thijs, Koen Wauters, Nora Gharib en meer dan 100 BV's spreken zich uit tegen Israëlisch geweld: \"België kan en moet meer doen\"",
+        "places": [
+            {
+                "name": "Israël",
+                "type": "country"
+            },
+            {
+                "name": "België",
+                "type": "country"
+            }
+        ],
+        "difficulty": "Israëlisch is adjective form of place name Israël."
+    },
+    {
+        "title": "Stad Brussel geeft taalpremie van 155 euro aan onderwijzers die Frans kunnen geven",
+        "places": [
+            {
+                "name": "Brussel",
+                "type": "municipality"
+            }
+        ],
+        "difficulty": ""
+    },
+    {
+        "title": "9-jarig meisje in kuit gebeten door loslopende hond in Ter Kamerenbos in Elsene",
+        "places": [
+            {
+                "name": "Elsene",
+                "type": "municipality"
+            },
+            {
+                "name": "Ter Kamerenbos",
+                "type": "other"
+            }
+        ],
+        "difficulty": "Ter Kamerenbos isn't a municipality, province or country."
+    },
+    {
+        "title": "\"Rusland bereidt zich voor op confrontatie met Europa\", waarschuwt Europees Commissievoorzitter Von der Leyen",
+        "places": [
+            {
+                "name": "Rusland",
+                "type": "country"
+            },
+            {
+                "name": "Europa",
+                "type": "other"
+            }
+        ],
+        "difficulty": "Europa isn't a country, but a continent."
+    },
+    {
+        "title": "Actievoerders protesteren aan Provinciehuis tegen plannen voor nieuwe verbindingsweg tussen Slijpe en centrum Middelkerke",
+        "places": [
+            {
+                "name": "Middelkerke",
+                "type": "municipality"
+            },
+            {
+                "name": "Slijpe",
+                "type": "municipality"
+            },
+            {
+                "name": "Provinciehuis",
+                "type": "other"
+            }
+        ],
+        "difficulty": "Provinciehuis is not a municipality, province or country."
+    },
+    {
+        "title": "'The shining' in het echt? Teamlid uit Zuid-Afrika valt collega's aan op geïsoleerde basis op Antarctica",
+        "places": [
+            {
+                "name": "Zuid-Afrika",
+                "type": "country"
+            },
+            {
+                "name": "Antarctica",
+                "type": "other"
+            }
+        ],
+        "difficulty": "Antarctica is not a country, but a continent."
+    }
+]


### PR DESCRIPTION
- [ ] add events input data from [track-vrt-nws](https://github.com/IsaacVerm/track-vrt-nws)
- [ ] add golden standard places: expected places extracted for a couple of article titles
- [ ] add [Datasette llm] command (with prompt) to extract places
- [ ] compare `Datasette llm` output with golden standard